### PR TITLE
feat: STX and stacking snapshot proposal voting extensions

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -3,8 +3,11 @@ name = "executor-dao"
 authors = []
 description = ""
 telemetry = false
-requirements = []
 costs_version = 2
+
+[[project.requirements]]
+boot_contracts = ["pox"]
+
 [contracts.ede000-governance-token]
 path = "contracts/extensions/ede000-governance-token.clar"
 depends_on = ["executor-dao", "governance-token-trait", "sip010-ft-trait"]
@@ -36,6 +39,10 @@ depends_on = ["executor-dao", "extension-trait", "ede000-governance-token"]
 [contracts.ede006-snapshot-proposal-voting]
 path = "contracts/extensions/ede006-snapshot-proposal-voting.clar"
 depends_on = ["executor-dao", "extension-trait"]
+
+[contracts.ede007-stacking-snapshot-proposal-voting]
+path = "contracts/extensions/ede007-stacking-snapshot-proposal-voting.clar"
+depends_on = []
 
 [contracts.edp000-bootstrap]
 path = "contracts/proposals/edp000-bootstrap.clar"

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,9 +1,16 @@
 [project]
 name = "executor-dao"
+authors = []
+description = ""
+telemetry = false
 requirements = []
-
+costs_version = 2
 [contracts.ede000-governance-token]
 path = "contracts/extensions/ede000-governance-token.clar"
+depends_on = ["executor-dao", "governance-token-trait", "sip010-ft-trait"]
+
+[contracts.ede000-governance-token-v2]
+path = "tests/proposals/ede000-governance-token-v2.clar"
 depends_on = ["executor-dao", "governance-token-trait", "sip010-ft-trait"]
 
 [contracts.ede001-proposal-voting]
@@ -26,9 +33,17 @@ depends_on = ["executor-dao", "extension-trait", "ede001-proposal-voting"]
 path = "contracts/extensions/ede005-dev-fund.clar"
 depends_on = ["executor-dao", "extension-trait", "ede000-governance-token"]
 
+[contracts.ede006-snapshot-proposal-voting]
+path = "contracts/extensions/ede006-snapshot-proposal-voting.clar"
+depends_on = ["executor-dao", "extension-trait"]
+
 [contracts.edp000-bootstrap]
 path = "contracts/proposals/edp000-bootstrap.clar"
 depends_on = ["executor-dao", "proposal-trait", "extension-trait", "ede000-governance-token", "ede001-proposal-voting", "ede002-proposal-submission", "ede003-emergency-proposals", "ede004-emergency-execute"]
+
+[contracts.edp001-1-dev-fund]
+path = "tests/proposals/edp001-1-dev-fund.clar"
+depends_on = ["ede000-governance-token", "executor-dao"]
 
 [contracts.edp001-dev-fund]
 path = "contracts/proposals/edp001-dev-fund.clar"
@@ -42,29 +57,12 @@ depends_on = ["ede004-emergency-execute", "executor-dao"]
 path = "contracts/proposals/edp003-allowlist-escrow-nft.clar"
 depends_on = ["proposal-trait", "nft-escrow"]
 
-
-[contracts.sip009-nft]
-path = "tests/proposals/sip009-nft.clar"
-depends_on = ["sip009-nft-trait"]
-
-[contracts.sip009-nft-trait]
-path = "tests/proposals/sip009-nft-trait.clar"
-depends_on = []
-
-[contracts.ede000-governance-token-v2]
-path = "tests/proposals/ede000-governance-token-v2.clar"
-depends_on = ["executor-dao", "governance-token-trait", "sip010-ft-trait"]
-
-[contracts.edp001-1-dev-fund]
-path = "tests/proposals/edp001-1-dev-fund.clar"
-depends_on = ["ede000-governance-token", "executor-dao"]
+[contracts.edp004-dao-change-governance]
+path = "tests/proposals/edp004-dao-change-governance.clar"
+depends_on = ["proposal-trait"]
 
 [contracts.edp005-dao-change-sample-config]
 path = "tests/proposals/edp005-dao-change-sample-config.clar"
-depends_on = ["proposal-trait"]
-
-[contracts.edp004-dao-change-governance]
-path = "tests/proposals/edp004-dao-change-governance.clar"
 depends_on = ["proposal-trait"]
 
 [contracts.edp006-dao-mint-burn-edg]
@@ -78,7 +76,6 @@ depends_on = ["proposal-trait"]
 [contracts.edp008-1-allowlist-nft-escrow]
 path = "tests/proposals/edp008-1-allowlist-nft-escrow.clar"
 depends_on = ["proposal-trait"]
-
 
 [contracts.executor-dao]
 path = "contracts/executor-dao.clar"
@@ -102,6 +99,14 @@ depends_on = []
 
 [contracts.proposal-trait]
 path = "contracts/traits/proposal-trait.clar"
+depends_on = []
+
+[contracts.sip009-nft]
+path = "tests/proposals/sip009-nft.clar"
+depends_on = ["sip009-nft-trait"]
+
+[contracts.sip009-nft-trait]
+path = "tests/proposals/sip009-nft-trait.clar"
 depends_on = []
 
 [contracts.sip010-ft-trait]

--- a/contracts/extensions/ede006-snapshot-proposal-voting.clar
+++ b/contracts/extensions/ede006-snapshot-proposal-voting.clar
@@ -1,0 +1,126 @@
+;; Title: EDE006 Snapshot Proposal Voting
+;; Author: Marvin Janssen
+;; Depends-On: 
+;; Synopsis:
+;; This extension is an EcosystemDAO concept that allows all STX holders to
+;; vote on proposals based on their STX balance.
+;; Description:
+;; This extension allows anyone with STX to vote on proposals. The maximum upper
+;; bound, or voting power, depends on the amount of STX tokens the tx-sender
+;; owned at the start block height of the proposal. The name "snapshot" comes
+;; from the fact that the extension effectively uses the STX balance sheet
+;; at a specific block heights to determine voting power.
+
+(impl-trait .extension-trait.extension-trait)
+(use-trait proposal-trait .proposal-trait.proposal-trait)
+(use-trait governance-token-trait .governance-token-trait.governance-token-trait)
+
+(define-constant err-unauthorised (err u3000))
+(define-constant err-proposal-already-executed (err u3001))
+(define-constant err-proposal-already-exists (err u3002))
+(define-constant err-unknown-proposal (err u3003))
+(define-constant err-proposal-already-concluded (err u3004))
+(define-constant err-proposal-inactive (err u3005))
+(define-constant err-insufficient-voting-capacity (err u3006))
+(define-constant err-end-block-height-not-reached (err u3007))
+
+(define-map proposals
+	principal
+	{
+		votes-for: uint,
+		votes-against: uint,
+		start-block-height: uint,
+		end-block-height: uint,
+		concluded: bool,
+		passed: bool,
+		proposer: principal
+	}
+)
+
+(define-map member-total-votes {proposal: principal, voter: principal} uint)
+
+;; --- Authorisation check
+
+(define-public (is-dao-or-extension)
+	(ok (asserts! (or (is-eq tx-sender .executor-dao) (contract-call? .executor-dao is-extension contract-caller)) err-unauthorised))
+)
+
+;; --- Internal DAO functions
+
+;; Proposals
+
+(define-public (add-proposal (proposal <proposal-trait>) (data {start-block-height: uint, end-block-height: uint, proposer: principal}))
+	(begin
+		(try! (is-dao-or-extension))
+		(asserts! (is-none (contract-call? .executor-dao executed-at proposal)) err-proposal-already-executed)
+		(print {event: "propose", proposal: proposal, proposer: tx-sender})
+		(ok (asserts! (map-insert proposals (contract-of proposal) (merge {votes-for: u0, votes-against: u0, concluded: false, passed: false} data)) err-proposal-already-exists))
+	)
+)
+
+;; --- Public functions
+
+;; Proposals
+
+(define-read-only (get-proposal-data (proposal principal))
+	(map-get? proposals proposal)
+)
+
+;; Votes
+
+(define-read-only (get-total-vote-capacity (voter principal) (height uint))
+	(at-block (unwrap! (get-block-info? id-header-hash height) none)
+		(some (stx-get-balance voter))
+	)
+)
+
+(define-read-only (get-current-total-votes (proposal principal) (voter principal))
+	(default-to u0 (map-get? member-total-votes {proposal: proposal, voter: voter}))
+)
+
+(define-public (vote (amount uint) (for bool) (proposal principal))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals proposal) err-unknown-proposal))
+			(new-total-votes (+ (get-current-total-votes proposal tx-sender) amount))
+		)
+		(asserts! (>= block-height (get start-block-height proposal-data)) err-proposal-inactive)
+		(asserts! (< block-height (get end-block-height proposal-data)) err-proposal-inactive)
+		(asserts!
+			(<= new-total-votes (unwrap! (get-total-vote-capacity tx-sender (get start-block-height proposal-data)) err-proposal-inactive))
+			err-insufficient-voting-capacity
+		)
+		(map-set member-total-votes {proposal: proposal, voter: tx-sender} new-total-votes)
+		(map-set proposals proposal
+			(if for
+				(merge proposal-data {votes-for: (+ (get votes-for proposal-data) amount)})
+				(merge proposal-data {votes-against: (+ (get votes-against proposal-data) amount)})
+			)
+		)
+		(print {event: "vote", proposal: proposal, voter: tx-sender, for: for, amount: amount})
+		(ok true)
+	)
+)
+
+;; Conclusion
+
+(define-public (conclude (proposal <proposal-trait>))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals (contract-of proposal)) err-unknown-proposal))
+			(passed (> (get votes-for proposal-data) (get votes-against proposal-data)))
+		)
+		(asserts! (not (get concluded proposal-data)) err-proposal-already-concluded)
+		(asserts! (>= block-height (get end-block-height proposal-data)) err-end-block-height-not-reached)
+		(map-set proposals (contract-of proposal) (merge proposal-data {concluded: true, passed: passed}))
+		(print {event: "conclude", proposal: proposal, passed: passed})
+		(and passed (try! (contract-call? .executor-dao execute proposal tx-sender)))
+		(ok passed)
+	)
+)
+
+;; --- Extension callback
+
+(define-public (callback (sender principal) (memo (buff 34)))
+	(ok true)
+)

--- a/contracts/extensions/ede007-stacking-snapshot-proposal-voting.clar
+++ b/contracts/extensions/ede007-stacking-snapshot-proposal-voting.clar
@@ -1,0 +1,130 @@
+;; Title: EDE007 Stacking Snapshot Proposal Voting
+;; Author: Marvin Janssen
+;; Depends-On: 
+;; Synopsis:
+;; This extension is an EcosystemDAO concept that allows all STX holders to
+;; vote on proposals based on the amount they were stacking at that time.
+;; Description:
+;; This extension allows anyone with STX to vote on proposals. The maximum upper
+;; bound, or voting power, depends on the amount of STX tokens the tx-sender
+;; was stacking at the start block height of the proposal. The name "snapshot"
+;; comes from the fact that the extension effectively uses the stacking amount
+;; at a specific block heights to determine voting power.
+
+(impl-trait .extension-trait.extension-trait)
+(use-trait proposal-trait .proposal-trait.proposal-trait)
+(use-trait governance-token-trait .governance-token-trait.governance-token-trait)
+
+(define-constant err-unauthorised (err u3000))
+(define-constant err-proposal-already-executed (err u3001))
+(define-constant err-proposal-already-exists (err u3002))
+(define-constant err-unknown-proposal (err u3003))
+(define-constant err-proposal-already-concluded (err u3004))
+(define-constant err-proposal-inactive (err u3005))
+(define-constant err-insufficient-voting-capacity (err u3006))
+(define-constant err-end-block-height-not-reached (err u3007))
+(define-constant err-no-voting-capacity (err u3008))
+
+(define-map proposals
+	principal
+	{
+		votes-for: uint,
+		votes-against: uint,
+		start-block-height: uint,
+		end-block-height: uint,
+		concluded: bool,
+		passed: bool,
+		proposer: principal
+	}
+)
+
+(define-map member-total-votes {proposal: principal, voter: principal} uint)
+
+;; --- Authorisation check
+
+(define-public (is-dao-or-extension)
+	(ok (asserts! (or (is-eq tx-sender .executor-dao) (contract-call? .executor-dao is-extension contract-caller)) err-unauthorised))
+)
+
+;; --- Internal DAO functions
+
+;; Proposals
+
+(define-public (add-proposal (proposal <proposal-trait>) (data {start-block-height: uint, end-block-height: uint, proposer: principal}))
+	(begin
+		(try! (is-dao-or-extension))
+		(asserts! (is-none (contract-call? .executor-dao executed-at proposal)) err-proposal-already-executed)
+		(print {event: "propose", proposal: proposal, proposer: tx-sender})
+		(ok (asserts! (map-insert proposals (contract-of proposal) (merge {votes-for: u0, votes-against: u0, concluded: false, passed: false} data)) err-proposal-already-exists))
+	)
+)
+
+;; --- Public functions
+
+;; Proposals
+
+(define-read-only (get-proposal-data (proposal principal))
+	(map-get? proposals proposal)
+)
+
+;; Votes
+
+;; get-stacker-info returns a tuple that looks like this:
+;; (some (tuple (amount-ustx uint) (first-reward-cycle uint) (lock-period uint) (pox-addr (tuple (hashbytes (buff 20)) (version (buff 1))))))
+
+(define-read-only (get-total-vote-capacity (voter principal) (height uint))
+	(at-block (unwrap! (get-block-info? id-header-hash height) none)
+		(get amount-ustx (contract-call? 'SP000000000000000000002Q6VF78.pox get-stacker-info voter))
+	)
+)
+
+(define-read-only (get-current-total-votes (proposal principal) (voter principal))
+	(default-to u0 (map-get? member-total-votes {proposal: proposal, voter: voter}))
+)
+
+(define-public (vote (amount uint) (for bool) (proposal principal))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals proposal) err-unknown-proposal))
+			(new-total-votes (+ (get-current-total-votes proposal tx-sender) amount))
+		)
+		(asserts! (>= block-height (get start-block-height proposal-data)) err-proposal-inactive)
+		(asserts! (< block-height (get end-block-height proposal-data)) err-proposal-inactive)
+		(asserts!
+			(<= new-total-votes (unwrap! (get-total-vote-capacity tx-sender (get start-block-height proposal-data)) err-no-voting-capacity))
+			err-insufficient-voting-capacity
+		)
+		(map-set member-total-votes {proposal: proposal, voter: tx-sender} new-total-votes)
+		(map-set proposals proposal
+			(if for
+				(merge proposal-data {votes-for: (+ (get votes-for proposal-data) amount)})
+				(merge proposal-data {votes-against: (+ (get votes-against proposal-data) amount)})
+			)
+		)
+		(print {event: "vote", proposal: proposal, voter: tx-sender, for: for, amount: amount})
+		(ok true)
+	)
+)
+
+;; Conclusion
+
+(define-public (conclude (proposal <proposal-trait>))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals (contract-of proposal)) err-unknown-proposal))
+			(passed (> (get votes-for proposal-data) (get votes-against proposal-data)))
+		)
+		(asserts! (not (get concluded proposal-data)) err-proposal-already-concluded)
+		(asserts! (>= block-height (get end-block-height proposal-data)) err-end-block-height-not-reached)
+		(map-set proposals (contract-of proposal) (merge proposal-data {concluded: true, passed: passed}))
+		(print {event: "conclude", proposal: proposal, passed: passed})
+		(and passed (try! (contract-call? .executor-dao execute proposal tx-sender)))
+		(ok passed)
+	)
+)
+
+;; --- Extension callback
+
+(define-public (callback (sender principal) (memo (buff 34)))
+	(ok true)
+)

--- a/tests/ede006-snapshot-proposal-voting_test.ts
+++ b/tests/ede006-snapshot-proposal-voting_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});

--- a/tests/ede007-stacking-snapshot-proposal-voting_test.ts
+++ b/tests/ede007-stacking-snapshot-proposal-voting_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});


### PR DESCRIPTION
This concept PR adds two new kind of voting contracts:

**EDE006 Snapshot Proposal Voting**

This concept extension allows anyone with STX to vote on proposals. The maximum upper bound, or voting power, depends on the amount of STX tokens the `tx-sender` owned at the start block height of the proposal. The name "snapshot" comes from the fact that the extension effectively uses the STX balance sheet at a specific block heights to determine voting power.

**EDE007 Stacking Snapshot Proposal Voting**

Same as EDE006, but allows voting based on the amount of STX being stacked by the `tx-sender` at the start block height of the proposal.