### PR TITLE
Adds cap on voting equal to the current minimum stacking amount - rea…

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -38,12 +38,12 @@ depends_on = ["ecosystem-dao", "extension-trait", "ede000-governance-token"]
 path = "contracts/extensions/ede006-treasury.clar"
 depends_on = ["ecosystem-dao", "extension-trait"]
 
-[contracts.ede007-snapshot-proposal-voting-v2]
-path = "contracts/extensions/ede007-snapshot-proposal-voting-v2.clar"
+[contracts.ede007-snapshot-proposal-voting-v3]
+path = "contracts/extensions/ede007-snapshot-proposal-voting-v3.clar"
 depends_on = ["ecosystem-dao", "extension-trait"]
 
-[contracts.ede008-funded-proposal-submission-v2]
-path = "contracts/extensions/ede008-funded-proposal-submission-v2.clar"
+[contracts.ede008-funded-proposal-submission-v3]
+path = "contracts/extensions/ede008-funded-proposal-submission-v3.clar"
 depends_on = ["ecosystem-dao", "extension-trait"]
 
 [contracts.ede009-governance-token-sale]

--- a/contracts/extensions/ede007-snapshot-proposal-voting-v3.clar
+++ b/contracts/extensions/ede007-snapshot-proposal-voting-v3.clar
@@ -83,7 +83,6 @@
 
 (define-read-only (get-historical-values (height uint) (who principal))
 	(at-block (unwrap! (get-block-info? id-header-hash height) none)
-		;;(some {user-balance: (stx-get-balance who), voting-cap: vote-cap})
 		(some {user-balance: (stx-get-balance who), voting-cap: (contract-call? 'SP000000000000000000002Q6VF78.pox get-stacking-minimum)})
 	)
 )
@@ -92,7 +91,6 @@
 	(let
 		(
 			(proposal-data (unwrap! (map-get? proposals proposal) err-unknown-proposal))
-			;;(start-block (get start-block-height proposal-data))
 			(new-total-votes (+ (get-current-total-votes proposal tx-sender) amount))
 			(historical-values (unwrap! (get-historical-values (get start-block-height proposal-data) tx-sender) err-proposal-inactive))
 		)

--- a/contracts/extensions/ede007-snapshot-proposal-voting-v3.clar
+++ b/contracts/extensions/ede007-snapshot-proposal-voting-v3.clar
@@ -1,0 +1,143 @@
+;; Title: EDE007 Snapshot Proposal Voting
+;; Author: Marvin Janssen
+;; Depends-On: 
+;; Synopsis:
+;; This extension is an EcosystemDAO concept that allows all STX holders to
+;; vote on proposals based on their STX balance.
+;; Description:
+;; This extension allows anyone with STX to vote on proposals. The maximum upper
+;; bound, or voting power, depends on the amount of STX tokens the tx-sender
+;; owned at the start block height of the proposal. The name "snapshot" comes
+;; from the fact that the extension effectively uses the STX balance sheet
+;; at a specific block heights to determine voting power. 
+;; Custom majority thresholds for voting are also possible on a per proposal basis.
+;; A custom majority of 66% mean the percent of votes for must be greater than 66 for
+;; the vote to carry.
+
+(impl-trait .extension-trait.extension-trait)
+(use-trait proposal-trait .proposal-trait.proposal-trait)
+
+(define-constant err-unauthorised (err u3000))
+(define-constant err-proposal-already-executed (err u3001))
+(define-constant err-proposal-already-exists (err u3002))
+(define-constant err-unknown-proposal (err u3003))
+(define-constant err-proposal-already-concluded (err u3004))
+(define-constant err-proposal-inactive (err u3005))
+(define-constant err-insufficient-voting-capacity (err u3006))
+(define-constant err-end-block-height-not-reached (err u3007))
+(define-constant err-not-majority (err u3008))
+(define-constant err-exceeds-voting-cap (err u3009))
+
+(define-constant custom-majority-upper u10000)
+(define-constant vote-cap u130000000000)
+
+(define-map proposals
+	principal
+	{
+		votes-for: uint,
+		votes-against: uint,
+		start-block-height: uint,
+		end-block-height: uint,
+		concluded: bool,
+		passed: bool,
+		custom-majority: (optional uint), ;; u10000 = 100%
+		proposer: principal
+	}
+)
+
+(define-map member-total-votes {proposal: principal, voter: principal} uint)
+
+;; --- Authorisation check
+
+(define-public (is-dao-or-extension)
+	(ok (asserts! (or (is-eq tx-sender .ecosystem-dao) (contract-call? .ecosystem-dao is-extension contract-caller)) err-unauthorised))
+)
+
+;; --- Internal DAO functions
+
+;; Proposals
+
+(define-public (add-proposal (proposal <proposal-trait>) (data {start-block-height: uint, end-block-height: uint, proposer: principal, custom-majority: (optional uint)}))
+	(begin
+		(try! (is-dao-or-extension))
+		(asserts! (is-none (contract-call? .ecosystem-dao executed-at proposal)) err-proposal-already-executed)
+		(asserts! (match (get custom-majority data) majority (> majority u5000) true) err-not-majority)
+		(print {event: "propose", proposal: proposal, proposer: tx-sender})
+		(ok (asserts! (map-insert proposals (contract-of proposal) (merge {votes-for: u0, votes-against: u0, concluded: false, passed: false} data)) err-proposal-already-exists))
+	)
+)
+
+;; --- Public functions
+
+;; Proposals
+
+(define-read-only (get-proposal-data (proposal principal))
+	(map-get? proposals proposal)
+)
+
+;; Votes
+
+(define-read-only (get-total-vote-capacity (voter principal) (height uint))
+	(at-block (unwrap! (get-block-info? id-header-hash height) none)
+		(some (stx-get-balance voter))
+	)
+)
+
+(define-read-only (get-current-total-votes (proposal principal) (voter principal))
+	(default-to u0 (map-get? member-total-votes {proposal: proposal, voter: voter}))
+)
+
+(define-public (vote (amount uint) (for bool) (proposal principal))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals proposal) err-unknown-proposal))
+			(new-total-votes (+ (get-current-total-votes proposal tx-sender) amount))
+		)
+		(asserts! (>= block-height (get start-block-height proposal-data)) err-proposal-inactive)
+		(asserts! (< block-height (get end-block-height proposal-data)) err-proposal-inactive)
+		(asserts!
+			(<= new-total-votes (unwrap! (get-total-vote-capacity tx-sender (get start-block-height proposal-data)) err-proposal-inactive))
+			err-insufficient-voting-capacity
+		)
+		(asserts! (< new-total-votes vote-cap) err-exceeds-voting-cap)
+			;;(<= new-total-votes (contract-call? 'SP000000000000000000002Q6VF78.pox get-stacking-minimum)))
+			
+		(map-set member-total-votes {proposal: proposal, voter: tx-sender} new-total-votes)
+		(map-set proposals proposal
+			(if for
+				(merge proposal-data {votes-for: (+ (get votes-for proposal-data) amount)})
+				(merge proposal-data {votes-against: (+ (get votes-against proposal-data) amount)})
+			)
+		)
+		(print {event: "vote", proposal: proposal, voter: tx-sender, for: for, amount: amount})
+		(ok true)
+	)
+)
+
+;; Conclusion
+
+(define-public (conclude (proposal <proposal-trait>))
+	(let
+		(
+			(proposal-data (unwrap! (map-get? proposals (contract-of proposal)) err-unknown-proposal))
+			(passed
+				(match (get custom-majority proposal-data)
+					majority (> (* (get votes-for proposal-data) custom-majority-upper) (* (+ (get votes-for proposal-data) (get votes-against proposal-data)) majority))
+					(> (get votes-for proposal-data) (get votes-against proposal-data))
+				)
+			)
+		)
+		(asserts! (not (get concluded proposal-data)) err-proposal-already-concluded)
+		(asserts! (>= block-height (get end-block-height proposal-data)) err-end-block-height-not-reached)
+		(map-set proposals (contract-of proposal) (merge proposal-data {concluded: true, passed: passed}))
+		(print {event: "conclude", proposal: proposal, passed: passed})
+		(and passed (try! (contract-call? .ecosystem-dao execute proposal tx-sender)))
+		(ok passed)
+	)
+)
+
+;; --- Extension callback
+
+(define-public (callback (sender principal) (memo (buff 34)))
+	(ok true)
+)

--- a/contracts/extensions/ede008-funded-proposal-submission-v3.clar
+++ b/contracts/extensions/ede008-funded-proposal-submission-v3.clar
@@ -35,7 +35,7 @@
 (define-map parameters (string-ascii 20) uint)
 
 (map-set parameters "funding-cost" u1000000000) ;; funding cost in uSTX. 1000 STX in this case.
-(map-set parameters "proposal-duration" u4032) ;; ~1 week based on a ~10 minute block time.
+(map-set parameters "proposal-duration" u1008) ;; ~4 weeks based on 4032 blocks at ~10 minute block time.
 (map-set parameters "proposal-start-delay" u6) ;; ~1 hour minimum delay before voting on a proposal can start.
 
 ;; --- Authorisation check

--- a/contracts/extensions/ede008-funded-proposal-submission-v3.clar
+++ b/contracts/extensions/ede008-funded-proposal-submission-v3.clar
@@ -35,7 +35,7 @@
 (define-map parameters (string-ascii 20) uint)
 
 (map-set parameters "funding-cost" u1000000000) ;; funding cost in uSTX. 1000 STX in this case.
-(map-set parameters "proposal-duration" u1008) ;; ~1 week based on a ~10 minute block time.
+(map-set parameters "proposal-duration" u4032) ;; ~1 week based on a ~10 minute block time.
 (map-set parameters "proposal-start-delay" u6) ;; ~1 hour minimum delay before voting on a proposal can start.
 
 ;; --- Authorisation check

--- a/contracts/extensions/ede008-funded-proposal-submission-v3.clar
+++ b/contracts/extensions/ede008-funded-proposal-submission-v3.clar
@@ -35,7 +35,7 @@
 (define-map parameters (string-ascii 20) uint)
 
 (map-set parameters "funding-cost" u1000000000) ;; funding cost in uSTX. 1000 STX in this case.
-(map-set parameters "proposal-duration" u1008) ;; ~4 weeks based on 4032 blocks at ~10 minute block time.
+(map-set parameters "proposal-duration" u288) ;; ~4 weeks is 4032 blocks at ~10 minute block time.
 (map-set parameters "proposal-start-delay" u6) ;; ~1 hour minimum delay before voting on a proposal can start.
 
 ;; --- Authorisation check

--- a/contracts/extensions/ede008-funded-proposal-submission-v3.clar
+++ b/contracts/extensions/ede008-funded-proposal-submission-v3.clar
@@ -1,0 +1,151 @@
+;; Title: EDE008 Funded Proposal Submission
+;; Author: Marvin Janssen
+;; Depends-On: EDE001
+;; Synopsis:
+;; This extension part of the core of ExecutorDAO. It allows members to
+;; bring proposals to the voting phase by funding them with a preset amount
+;; of tokens. 
+;; Description:
+;; The level of funding is determined by a DAO parameter and can be changed by proposal.
+;; Any funder can reclaim their stx up to the point the proposal is fully funded and submitted.
+;; Proposals can also be marked as refundable in which case a funder can reclaim their stx
+;; even after submission (during or after the voting period).
+;; This extension provides the ability for the final funding transaction to set a
+;; custom majority for voting. This changes the threshold from the 
+;; default of 50% to anything up to 100%.
+
+(impl-trait .extension-trait.extension-trait)
+(use-trait proposal-trait .proposal-trait.proposal-trait)
+
+(define-constant err-unauthorised (err u3100))
+(define-constant err-not-governance-token (err u3101))
+(define-constant err-insufficient-balance (err u3102))
+(define-constant err-unknown-parameter (err u3103))
+(define-constant err-proposal-minimum-start-delay (err u3104))
+(define-constant err-proposal-maximum-start-delay (err u3105))
+(define-constant err-already-funded (err u3106))
+(define-constant err-nothing-to-refund (err u3107))
+(define-constant err-refund-not-allowed (err u3108))
+
+(define-map refundable-proposals principal bool)
+(define-map funded-proposals principal bool)
+(define-map proposal-funding principal uint)
+(define-map funding-per-principal {proposal: principal, funder: principal} uint)
+
+(define-map parameters (string-ascii 20) uint)
+
+(map-set parameters "funding-cost" u1000000000) ;; funding cost in uSTX. 1000 STX in this case.
+(map-set parameters "proposal-duration" u1008) ;; ~1 week based on a ~10 minute block time.
+(map-set parameters "proposal-start-delay" u6) ;; ~1 hour minimum delay before voting on a proposal can start.
+
+;; --- Authorisation check
+
+(define-public (is-dao-or-extension)
+	(ok (asserts! (or (is-eq tx-sender .ecosystem-dao) (contract-call? .ecosystem-dao is-extension contract-caller)) err-unauthorised))
+)
+
+;; --- Internal DAO functions
+
+;; Proposals
+
+(define-private (submit-proposal-for-vote (proposal <proposal-trait>) (start-block-height uint) (custom-majority (optional uint)))
+	(contract-call? .ede007-snapshot-proposal-voting-v3 add-proposal
+		proposal
+		{
+			start-block-height: start-block-height,
+			end-block-height: (+ start-block-height (try! (get-parameter "proposal-duration"))),
+			custom-majority: custom-majority,
+			proposer: tx-sender ;; change to original submitter
+		}
+	)
+)
+
+;; Parameters
+
+(define-public (set-parameter (parameter (string-ascii 20)) (value uint))
+	(begin
+		(try! (is-dao-or-extension))
+		(try! (get-parameter parameter))
+		(ok (map-set parameters parameter value))
+	)
+)
+
+;; Refunds
+
+(define-public (set-refundable (proposal principal) (refundable bool))
+	(begin
+		(try! (is-dao-or-extension))
+		(ok (map-set refundable-proposals proposal refundable))
+	)
+)
+
+;; --- Public functions
+
+;; Parameters
+
+(define-read-only (get-parameter (parameter (string-ascii 20)))
+	(ok (unwrap! (map-get? parameters parameter) err-unknown-parameter))
+)
+
+;; Funding status
+
+(define-read-only (is-proposal-funded (proposal principal))
+	(default-to false (map-get? funded-proposals proposal))
+)
+
+(define-read-only (get-proposal-funding (proposal principal))
+	(default-to u0 (map-get? proposal-funding proposal))
+)
+
+(define-read-only (get-proposal-funding-by-principal (proposal principal) (funder principal))
+	(default-to u0 (map-get? funding-per-principal {proposal: proposal, funder: funder}))
+)
+
+(define-read-only (can-refund (proposal principal) (funder principal))
+	(or
+		(default-to false (map-get? refundable-proposals proposal))
+		(and (not (is-proposal-funded proposal)) (is-eq funder tx-sender))
+	)
+)
+
+;; Proposals
+
+(define-public (fund (proposal <proposal-trait>) (amount uint) (custom-majority (optional uint)))
+	(let
+		(
+			(proposal-principal (contract-of proposal))
+			(current-total-funding (get-proposal-funding proposal-principal))
+			(funding-cost (try! (get-parameter "funding-cost")))
+			(difference (if (> funding-cost current-total-funding) (- funding-cost current-total-funding) u0))
+			(funded (<= difference amount))
+			(transfer-amount (if funded difference amount))
+		)
+		(asserts! (not (is-proposal-funded proposal-principal)) err-already-funded)
+		(and (> transfer-amount u0) (try! (stx-transfer? transfer-amount tx-sender .ede006-treasury)))
+		(map-set funding-per-principal {proposal: proposal-principal, funder: tx-sender} (+ (get-proposal-funding-by-principal proposal-principal tx-sender) transfer-amount))
+		(map-set proposal-funding proposal-principal (+ current-total-funding transfer-amount))
+		(asserts! funded (ok false))
+		(map-set funded-proposals proposal-principal true)
+		(submit-proposal-for-vote proposal (+ block-height (try! (get-parameter "proposal-start-delay"))) custom-majority)
+	)
+)
+
+(define-public (refund (proposal principal) (funder (optional principal)))
+	(let
+		(
+			(recipient (default-to tx-sender funder))
+			(refund-amount (get-proposal-funding-by-principal proposal recipient))
+		)
+		(asserts! (> refund-amount u0) err-nothing-to-refund)
+		(asserts! (can-refund proposal recipient) err-refund-not-allowed)
+		(map-set funding-per-principal {proposal: proposal, funder: recipient} u0)
+		(map-set proposal-funding proposal (- (get-proposal-funding proposal) refund-amount))
+		(contract-call? .ede006-treasury stx-transfer refund-amount recipient none)
+	)
+)
+
+;; --- Extension callback
+
+(define-public (callback (sender principal) (memo (buff 34)))
+	(ok true)
+)

--- a/contracts/proposals/edp000-edao-bootstrap.clar
+++ b/contracts/proposals/edp000-edao-bootstrap.clar
@@ -1,9 +1,9 @@
 ;; Title: EDP000 Bootstrap
-;; Author: Marvin Janssen
+;; Author: Clarity Lab (Mike Cohen, Marvin Janssen)
 ;; Synopsis: Bootstraps the DAO
 ;; Description:
-;; The bootstrap proposal sets the starting conditions for the DAO. The extensions
-;; initially active, the DAOs parameters and the executive team.
+;; The bootstrap proposal sets the starting conditions for the DAO. Activates
+;; initial extensions and sets the DAOs parameters and the executive team.
 
 
 (impl-trait .proposal-trait.proposal-trait)
@@ -15,19 +15,20 @@
 			(list
 				{extension: .ede004-emergency-execute, enabled: true}
 				{extension: .ede006-treasury, enabled: true}
-				{extension: .ede007-snapshot-proposal-voting-v2, enabled: true}
-				{extension: .ede008-funded-proposal-submission-v2, enabled: true}
+				{extension: .ede007-snapshot-proposal-voting-v3, enabled: true}
+				{extension: .ede008-funded-proposal-submission-v3, enabled: true}
 			)
 		))
 
-		;; Set executive team members.
+		;; Set executive parameters.
 		(try! (contract-call? .ede004-emergency-execute set-executive-team-member 'SPND1YC648T2SDW26NACCB8GAY8KSZJPNBS26GFD true))
 		(try! (contract-call? .ede004-emergency-execute set-executive-team-member 'SP3JP0N1ZXGASRJ0F7QAHWFPGTVK9T2XNXDB908Z true))
 		(try! (contract-call? .ede004-emergency-execute set-executive-team-member 'SP3YZYAR5T90J6GCZ9M0338WMT5MTZ7G671JED9P0 true))
+		(try! (contract-call? .ede004-emergency-execute set-executive-team-sunset-height (+ block-height u13140))) 
+		(try! (contract-call? .ede004-emergency-execute set-signals-required u2))
 
-		;; signal from 2 out of 3 team members required.
-		(try! (contract-call? .ede004-emergency-execute set-executive-team-sunset-height u13140)) 
-		(try! (contract-call? .ede004-emergency-execute set-signals-required u2)) 
+		;; Set dao parameters.
+		(try! (contract-call? .ede008-funded-proposal-submission-v3 set-parameter "funding-cost" u10000000)) 
 
 		(print "Ecosystem DAO has risen.")
 		(ok true)

--- a/contracts/proposals/testnet/edp000-bootstrap.clar
+++ b/contracts/proposals/testnet/edp000-bootstrap.clar
@@ -21,8 +21,8 @@
 				{extension: .ede002-threshold-proposal-submission, enabled: true}
 				{extension: .ede003-emergency-proposals, enabled: true}
 				{extension: .ede004-emergency-execute, enabled: true}
-				{extension: .ede007-snapshot-proposal-voting-v2, enabled: true}
-				{extension: .ede008-funded-proposal-submission-v2, enabled: true}
+				{extension: .ede007-snapshot-proposal-voting-v3, enabled: true}
+				{extension: .ede008-funded-proposal-submission-v3, enabled: true}
 			)
 		))
 
@@ -36,9 +36,11 @@
 		(try! (contract-call? .ede004-emergency-execute set-executive-team-member 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG true))
 		(try! (contract-call? .ede004-emergency-execute set-executive-team-member 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC true))
 		(try! (contract-call? .ede004-emergency-execute set-signals-required u3)) ;; signal from 3 out of 4 team members requied.
+		(try! (contract-call? .ede004-emergency-execute set-executive-team-sunset-height (+ block-height u13140))) 
 
 		;; Make EDP003 refundable
-		(try! (contract-call? .ede008-funded-proposal-submission-v2 set-refundable .edp003-allowlist-escrow-nft true)) ;; signal from 3 out of 4 team members requied.
+		(try! (contract-call? .ede008-funded-proposal-submission-v3 set-refundable .edp003-allowlist-escrow-nft true)) ;; signal from 3 out of 4 team members requied.
+		(try! (contract-call? .ede008-funded-proposal-submission-v3 set-parameter "funding-cost" u1000000000)) 
 
 		;; Mint initial token supply.
 		(try! (contract-call? .ede000-governance-token edg-mint-many

--- a/contracts/proposals/testnet/edp004-enable-snapshot-voting.clar
+++ b/contracts/proposals/testnet/edp004-enable-snapshot-voting.clar
@@ -13,6 +13,6 @@
 (impl-trait .proposal-trait.proposal-trait)
 
 (define-public (execute (sender principal))
-	(try! (contract-call? .ecosystem-dao set-extension .ede007-snapshot-proposal-voting-v2 true))
-	(contract-call? .ecosystem-dao set-extension .ede008-funded-proposal-submission-v2 true)
+	(try! (contract-call? .ecosystem-dao set-extension .ede007-snapshot-proposal-voting-v3 true))
+	(contract-call? .ecosystem-dao set-extension .ede008-funded-proposal-submission-v3 true)
 )

--- a/tests/ede007-snapshot-proposal-voting_test.ts
+++ b/tests/ede007-snapshot-proposal-voting_test.ts
@@ -2,30 +2,8 @@
 import { types, Clarinet, Chain, Account } from "https://deno.land/x/clarinet@v0.31.1/index.ts";
 import { Utils } from "./src/utils.ts";
 import { EDE007SnapshotProposalVotingClient, EDE007SnapshotProposalVotingErrCode } from "./src/ede007-snapshot-proposal-voting-client.ts";
-import { EDE008FundedProposalSubmissionClient } from "./src/ede008-funded-proposal-submission-client.ts";
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
-const getDurations = (blockHeight: number, submissionClient: EDE008FundedProposalSubmissionClient): any => {
-    const duration1 = submissionClient.getParameter('proposal-duration').result.split('ok u')[1]
-    const proposalDuration = Number(duration1.split(')')[0])
-    const proposalStartDelay = 144
-    const startHeight = blockHeight + proposalStartDelay - 1
-    const endHeight = startHeight + proposalDuration
-    const emergencyProposalDuration = 144
-    const emergencyStartHeight = blockHeight + emergencyProposalDuration
-    const emergencyEndHeight = blockHeight + emergencyProposalDuration - 1
-
-    return {
-        startHeight: startHeight + 2,
-        endHeight: endHeight + 2,
-        proposalDuration,
-        proposalStartDelay,
-        emergencyProposalDuration,
-        emergencyEndHeight,
-        emergencyStartHeight,
-    }
-}
-      
 const assertProposal = (
     customMajority: number,
     concluded: boolean,
@@ -258,5 +236,45 @@ Clarinet.test({
 
       assertProposal(8000, true, true, 19, 81, 9, 1017, daisy.address, contractEDP004, ede007SnapshotProposalVotingClient);
   
+    }
+  });
+
+  Clarinet.test({
+    name: "Ensure vote fails if exceed voting cap.",
+    fn(chain: Chain, accounts: Map<string, Account>) {
+      const {
+        deployer, 
+        exeDaoClient,
+        daisy,
+        phil,
+        contractEDP000,
+        contractEDP004,
+        ede007SnapshotProposalVotingClient,
+        ede008FundedProposalSubmissionClient
+      } = utils.setup(chain, accounts)
+
+      let block = chain.mineBlock([
+        exeDaoClient.construct(contractEDP000, deployer.address),
+      ]);
+      block.receipts[0].result.expectOk().expectBool(true)
+
+      const majority = 8000;
+      block = chain.mineBlock([
+        ede008FundedProposalSubmissionClient.fund(contractEDP004, ONE_THOUSAND_STX, majority, daisy.address),
+      ]);
+      block.receipts[0].result.expectOk().expectBool(true)
+      assertProposal(8000, false, false, 0, 0, 9, 1017, daisy.address, contractEDP004, ede007SnapshotProposalVotingClient);
+
+      ede008FundedProposalSubmissionClient.getParameter("proposal-start-delay").result.expectOk().expectUint(6)
+      ede008FundedProposalSubmissionClient.getParameter("proposal-duration").result.expectOk().expectUint(1008)
+
+      chain.mineEmptyBlock(block.height + 6);
+
+      block = chain.mineBlock([
+        ede007SnapshotProposalVotingClient.vote(130000000000, true, contractEDP004, daisy.address),
+        ede007SnapshotProposalVotingClient.vote(129999999999, true, contractEDP004, phil.address),
+      ]);
+      block.receipts[0].result.expectErr().expectUint(EDE007SnapshotProposalVotingErrCode.err_exceeds_voting_cap)
+      block.receipts[1].result.expectOk().expectBool(true)  
     }
   });

--- a/tests/ede007-snapshot-proposal-voting_test.ts
+++ b/tests/ede007-snapshot-proposal-voting_test.ts
@@ -50,7 +50,11 @@ Clarinet.test({
         exeDaoClient.construct(contractEDP000, deployer.address),
       ]);
       block.receipts[0].result.expectOk().expectBool(true)
-      ede007SnapshotProposalVotingClient.getTotalVoteCapacity(phil.address, 1).result.expectSome().expectUint(100000000000000)
+      //ede007SnapshotProposalVotingClient.getTotalVoteCapacity(phil.address, 1).result.expectSome().expectUint(100000000000000)
+      assertEquals(
+        ede007SnapshotProposalVotingClient.getHistoricalValues(1, phil.address).result.expectSome().expectTuple(),
+        { 'user-balance': 'u100000000000000', 'voting-cap': 'u2083333333333'}
+      );
     }
   });
   
@@ -117,9 +121,9 @@ Clarinet.test({
         ede007SnapshotProposalVotingClient.vote(500, true, contractEDP003, daisy.address),
       ]);
       block.receipts[0].result.expectErr().expectUint(EDE007SnapshotProposalVotingErrCode.err_proposal_inactive)
-  
+
     }
-  });  
+  });
   
   Clarinet.test({
     name: "Ensure proposal fails if votes for equals the custom majority.",
@@ -271,8 +275,8 @@ Clarinet.test({
       chain.mineEmptyBlock(block.height + 6);
 
       block = chain.mineBlock([
-        ede007SnapshotProposalVotingClient.vote(130000000000, true, contractEDP004, daisy.address),
-        ede007SnapshotProposalVotingClient.vote(129999999999, true, contractEDP004, phil.address),
+        ede007SnapshotProposalVotingClient.vote(2083333333333, true, contractEDP004, daisy.address),
+        ede007SnapshotProposalVotingClient.vote(2083333333332, true, contractEDP004, phil.address),
       ]);
       block.receipts[0].result.expectErr().expectUint(EDE007SnapshotProposalVotingErrCode.err_exceeds_voting_cap)
       block.receipts[1].result.expectOk().expectBool(true)  

--- a/tests/ede008-funded-proposal-submission_test.ts
+++ b/tests/ede008-funded-proposal-submission_test.ts
@@ -25,6 +25,9 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true)
     ede008FundedProposalSubmissionClient.getParameter("funding-cost").result.expectOk().expectUint(ONE_THOUSAND_STX)
+    
+    // Note: tests expect proposal-duration=1008
+
     ede008FundedProposalSubmissionClient.getParameter("proposal-duration").result.expectOk().expectUint(1008)
     ede008FundedProposalSubmissionClient.getParameter("proposal-start-delay").result.expectOk().expectUint(6)
 

--- a/tests/src/ede007-snapshot-proposal-voting-client.ts
+++ b/tests/src/ede007-snapshot-proposal-voting-client.ts
@@ -39,6 +39,10 @@ export class EDE007SnapshotProposalVotingClient {
     return this.callReadOnlyFn("get-total-vote-capacity", [types.principal(voter), types.uint(height)]);
   }
 
+  getHistoricalValues(height: number, voter: string): ReadOnlyFn {
+    return this.callReadOnlyFn("get-historical-values", [types.uint(height), types.principal(voter)]);
+  }
+
   getProposalData(proposal: string): ReadOnlyFn {
     return this.callReadOnlyFn("get-proposal-data", [types.principal(proposal)]);
   }

--- a/tests/src/ede007-snapshot-proposal-voting-client.ts
+++ b/tests/src/ede007-snapshot-proposal-voting-client.ts
@@ -16,7 +16,8 @@ export enum EDE007SnapshotProposalVotingErrCode {
   err_proposal_inactive=3005,
   err_insufficient_voting_capacity=3006,
   err_end_block_height_not_reached=3007,
-  err_not_majority=3008
+  err_not_majority=3008,
+  err_exceeds_voting_cap=3009
   }
 
 export class EDE007SnapshotProposalVotingClient {

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -150,8 +150,8 @@ export class Utils {
     const contractEDE004 = accounts.get("deployer")!.address + '.ede004-emergency-execute';
     const contractEDE005 = accounts.get("deployer")!.address + '.ede005-dev-fund';
     const contractEDE006 = accounts.get("deployer")!.address + '.ede006-treasury';
-    const contractEDE007 = accounts.get("deployer")!.address + '.ede007-snapshot-proposal-voting-v2';
-    const contractEDE008 = accounts.get("deployer")!.address + '.ede008-funded-proposal-submission-v2';
+    const contractEDE007 = accounts.get("deployer")!.address + '.ede007-snapshot-proposal-voting-v3';
+    const contractEDE008 = accounts.get("deployer")!.address + '.ede008-funded-proposal-submission-v3';
     const contractEDE009 = accounts.get("deployer")!.address + '.ede009-governance-token-sale';
     const contractNftEscrow = accounts.get("deployer")!.address + '.nft-escrow';
     const contractNft = accounts.get("deployer")!.address + '.sip009-nft';
@@ -170,8 +170,8 @@ export class Utils {
     const ede004EmergencyExecuteClient = new EDE004EmergencyExecuteClient(chain, deployer, 'ede004-emergency-execute');
     const ede005DevFundClient = new EDE005DevFundClient(chain, deployer, 'ede005-dev-fund');
     const ede006TreasuryClient = new EDE006TreasuryClient(chain, deployer, 'ede006-treasury');
-    const ede007SnapshotProposalVotingClient = new EDE007SnapshotProposalVotingClient(chain, deployer, 'ede007-snapshot-proposal-voting-v2');
-    const ede008FundedProposalSubmissionClient = new EDE008FundedProposalSubmissionClient(chain, deployer, 'ede008-funded-proposal-submission-v2');
+    const ede007SnapshotProposalVotingClient = new EDE007SnapshotProposalVotingClient(chain, deployer, 'ede007-snapshot-proposal-voting-v3');
+    const ede008FundedProposalSubmissionClient = new EDE008FundedProposalSubmissionClient(chain, deployer, 'ede008-funded-proposal-submission-v3');
     const ede009GovernanceTokenSaleClient = new EDE009GovernanceTokenSaleClient(chain, deployer, 'ede009-governance-token-sale');
     const nftEscrowClient = new NftEscrowClient(chain, deployer, 'nft-escrow');
     const nftClient = new NftClient(chain, deployer, 'sip009-nft');


### PR DESCRIPTION
Implements requirement from 2.1 team (Jude, Jenny) to cap the voting power to the current stacking minimum.

The cap is added as a constant rather than by pulling from pox.clar because running `clarinet requirement add SP...pox.clar` led to unresolvable errors and without being able to add the pox contract the contract code would need to change from the tested version.